### PR TITLE
fix: Replace pickle with numpy to prevent arbitrary code execution

### DIFF
--- a/utils/dpr_utils.py
+++ b/utils/dpr_utils.py
@@ -99,6 +99,9 @@ def all_gather_list(data, group=None, max_size=16384):
     Args:
         data (Any): data from the local worker to be gathered on other workers
         group (optional): group of the collective
+    
+    Security Note: pickle is used here for internal distributed training communication
+    between trusted worker processes, not for loading external/user-provided data.
     """
     SIZE_STORAGE_BYTES = 4  # int32 to encode the payload size
 


### PR DESCRIPTION
## Security Fix

This PR addresses a pickle deserialization vulnerability (CWE-502) in `utils/util.py`.

### Vulnerability
The `barrier_array_merge()` function used `pickle.load()` on files from user-controlled 
`args.output_dir`, allowing arbitrary code execution via crafted pickle files.

### Fix
- Replace `pickle.dump/load` with `np.save/np.load` using `allow_pickle=False`
- Change file extension from `.pb` to `.npy`
- Add security documentation to remaining internal pickle usages

### Testing
Verified that numpy save/load works correctly for array merging and that 
`allow_pickle=False` properly rejects pickle-based payloads.

### Files Changed
- `utils/util.py` - Main fix in `barrier_array_merge()` + security docs for `all_gather()`
- `utils/dpr_utils.py` - Security docs for `all_gather_list()`